### PR TITLE
feature/#115 add a check box for household items in the visit form

### DIFF
--- a/__tests__/app/checkin/__snapshots__/Checkin.test.tsx.snap
+++ b/__tests__/app/checkin/__snapshots__/Checkin.test.tsx.snap
@@ -376,23 +376,43 @@ exports[`CheckedIn should match snapshot when clientData fetched 1`] = `
           type="checkbox"
         />
       </div>
+      <div
+        className="formItem"
+      >
+        <label
+          htmlFor="householdItem"
+        >
+          Household Items
+        </label>
+        <input
+          checked={false}
+          id="householdItem"
+          label="Household Items"
+          onChange={[Function]}
+          type="checkbox"
+        />
+      </div>
     </div>
-    <h2>
-      Household items
-    </h2>
     <div
-      className="formItem"
+      hidden={true}
     >
-      <label
-        htmlFor="household"
-      />
-      <textarea
-        id="household"
-        onChange={[Function]}
-        rows={3}
-        type="textarea"
-        value=""
-      />
+      <h2>
+        Household items
+      </h2>
+      <div
+        className="formItem"
+      >
+        <label
+          htmlFor="household"
+        />
+        <textarea
+          id="household"
+          onChange={[Function]}
+          rows={3}
+          type="textarea"
+          value=""
+        />
+      </div>
     </div>
     <h2>
       Notes

--- a/__tests__/app/checkin/__snapshots__/Checkin.test.tsx.snap
+++ b/__tests__/app/checkin/__snapshots__/Checkin.test.tsx.snap
@@ -360,6 +360,22 @@ exports[`CheckedIn should match snapshot when clientData fetched 1`] = `
           type="checkbox"
         />
       </div>
+      <div
+        className="formItem"
+      >
+        <label
+          htmlFor="food"
+        >
+          Food
+        </label>
+        <input
+          checked={false}
+          id="food"
+          label="Food"
+          onChange={[Function]}
+          type="checkbox"
+        />
+      </div>
     </div>
     <h2>
       Household items

--- a/__tests__/components/Visit/__snapshots__/VisitInfoForm.test.tsx.snap
+++ b/__tests__/components/Visit/__snapshots__/VisitInfoForm.test.tsx.snap
@@ -275,23 +275,43 @@ exports[`Visit Info Form Component matches snapshot without any props 1`] = `
         type="checkbox"
       />
     </div>
+    <div
+      className="formItem"
+    >
+      <label
+        htmlFor="householdItem"
+      >
+        Household Items
+      </label>
+      <input
+        checked={false}
+        id="householdItem"
+        label="Household Items"
+        onChange={[Function]}
+        type="checkbox"
+      />
+    </div>
   </div>
-  <h2>
-    Household items
-  </h2>
   <div
-    className="formItem"
+    hidden={true}
   >
-    <label
-      htmlFor="household"
-    />
-    <textarea
-      id="household"
-      onChange={[Function]}
-      rows={3}
-      type="textarea"
-      value=""
-    />
+    <h2>
+      Household items
+    </h2>
+    <div
+      className="formItem"
+    >
+      <label
+        htmlFor="household"
+      />
+      <textarea
+        id="household"
+        onChange={[Function]}
+        rows={3}
+        type="textarea"
+        value=""
+      />
+    </div>
   </div>
   <h2>
     Notes

--- a/__tests__/components/Visit/__snapshots__/VisitInfoForm.test.tsx.snap
+++ b/__tests__/components/Visit/__snapshots__/VisitInfoForm.test.tsx.snap
@@ -259,6 +259,22 @@ exports[`Visit Info Form Component matches snapshot without any props 1`] = `
         type="checkbox"
       />
     </div>
+    <div
+      className="formItem"
+    >
+      <label
+        htmlFor="food"
+      >
+        Food
+      </label>
+      <input
+        checked={false}
+        id="food"
+        label="Food"
+        onChange={[Function]}
+        type="checkbox"
+      />
+    </div>
   </div>
   <h2>
     Household items

--- a/app/profile/[userId]/visit/[visitId]/printout/page.tsx
+++ b/app/profile/[userId]/visit/[visitId]/printout/page.tsx
@@ -33,6 +33,7 @@ export default function Printout({ params }: PrintoutProps) {
             const specialRequestItemKeys = [
                 'backpack',
                 'sleepingBag',
+                'food',
                 'busTicket',
                 'orcaCard',
                 'giftCard',
@@ -47,6 +48,7 @@ export default function Printout({ params }: PrintoutProps) {
                 clothingGirl: 'Kids (Girl)',
                 backpack: 'Backpack',
                 sleepingBag: 'Sleeping Bag',
+                food: 'Food',
                 busTicket: 'Bus Ticket',
                 orcaCard: 'Orca Card',
                 giftCard: 'Gift Card',

--- a/app/profile/[userId]/visit/[visitId]/printout/page.tsx
+++ b/app/profile/[userId]/visit/[visitId]/printout/page.tsx
@@ -39,6 +39,7 @@ export default function Printout({ params }: PrintoutProps) {
                 'giftCard',
                 'financialAssistance',
                 'diaper',
+                'householdItem',
             ];
             // What we want the form to label each checkbox
             const itemLabels = {
@@ -54,6 +55,7 @@ export default function Printout({ params }: PrintoutProps) {
                 giftCard: 'Gift Card',
                 diaper: 'Diapers',
                 financialAssistance: 'Financial Assistance',
+                householdItem: 'Household Items',
             };
             let ans: typeof formData = [];
             // Get clothing items to show

--- a/components/Visit/VisitDetail.tsx
+++ b/components/Visit/VisitDetail.tsx
@@ -19,6 +19,7 @@ function VisitDetail(props: VisitDetailProps) {
         kidsQ,
         backpack,
         sleepingBag,
+        food,
         busTicket,
         orcaCard,
         diaper,
@@ -47,6 +48,7 @@ function VisitDetail(props: VisitDetailProps) {
             <h2>Special Requests</h2>
             {backpack ||
             sleepingBag ||
+            food ||
             busTicket ||
             orcaCard ||
             giftCard ||
@@ -56,6 +58,7 @@ function VisitDetail(props: VisitDetailProps) {
                     <div className={styles.row}>
                         {backpack ? <p>{'Backpack ✔️'}</p> : ''}
                         {sleepingBag ? <p>{'Sleeping Bag ✔️'}</p> : ''}
+                        {food ? <p>{'Food ✔️'}</p> : ''}
                     </div>
                     <div className={styles.row}>
                         {busTicket ? <p>Bus Tickets: {busTicket}</p> : ''}

--- a/components/Visit/VisitDetail.tsx
+++ b/components/Visit/VisitDetail.tsx
@@ -27,6 +27,7 @@ function VisitDetail(props: VisitDetailProps) {
         financialAssistance,
         household,
         notes,
+        householdItem,
     } = visitData;
     return (
         <div>
@@ -53,12 +54,14 @@ function VisitDetail(props: VisitDetailProps) {
             orcaCard ||
             giftCard ||
             diaper ||
+            householdItem ||
             financialAssistance ? (
                 <div className={styles.rowContainer}>
                     <div className={styles.row}>
                         {backpack ? <p>{'Backpack ✔️'}</p> : ''}
                         {sleepingBag ? <p>{'Sleeping Bag ✔️'}</p> : ''}
                         {food ? <p>{'Food ✔️'}</p> : ''}
+                        {householdItem ? <p>{'Household Items ✔️'}</p> : ''}
                     </div>
                     <div className={styles.row}>
                         {busTicket ? <p>Bus Tickets: {busTicket}</p> : ''}

--- a/components/Visit/VisitInfoForm.tsx
+++ b/components/Visit/VisitInfoForm.tsx
@@ -22,6 +22,7 @@ const defaultVisitData = {
     notes: '',
     backpack: false,
     sleepingBag: false,
+    food: false,
     mensQ: '',
     womensQ: '',
     kidsQ: '',
@@ -209,6 +210,13 @@ export default function VisitInfoForm({
                     label="Sleeping Bag"
                     checked={!!visitData.sleepingBag}
                     onChange={handleChange('sleepingBag')}
+                />
+                <FormItem
+                    type="checkbox"
+                    id="food"
+                    label="Food"
+                    checked={!!visitData.food}
+                    onChange={handleChange('food')}
                 />
             </FormRow>
 

--- a/components/Visit/VisitInfoForm.tsx
+++ b/components/Visit/VisitInfoForm.tsx
@@ -26,6 +26,7 @@ const defaultVisitData = {
     mensQ: '',
     womensQ: '',
     kidsQ: '',
+    householdItem: false,
 };
 
 const toInt = (value: string) => parseInt(value) || 0;
@@ -89,9 +90,31 @@ export default function VisitInfoForm({
         if (e.target.type === 'checkbox') {
             value = e.target.checked;
         } else value = e.target.value;
-        const data = transformData({ ...visitData, [key]: value });
-        onChange && onChange(data);
-        setVisitData({ ...visitData, [key]: value });
+
+        if (key === 'householdItem') {
+            const booleanValue = Boolean(value);
+
+            setVisitData((visitData) => ({
+                ...visitData,
+                // reset household items notes if householdItem is unchecked
+                household: !booleanValue ? '' : visitData.household,
+                householdItem: booleanValue,
+            }));
+        } else {
+            setVisitData((visitData) => ({
+                ...visitData,
+                [key]: value,
+            }));
+        }
+
+        if (onChange) {
+            const updatedData = {
+                ...visitData,
+                [key]: value,
+                ...(key === 'householdItem' && !value && { household: '' }),
+            };
+            onChange(transformData(updatedData));
+        }
     };
     return (
         <Form onSubmit={handleSubmit}>
@@ -218,17 +241,26 @@ export default function VisitInfoForm({
                     checked={!!visitData.food}
                     onChange={handleChange('food')}
                 />
+                <FormItem
+                    type="checkbox"
+                    id="householdItem"
+                    label="Household Items"
+                    checked={!!visitData.householdItem}
+                    onChange={handleChange('householdItem')}
+                />
             </FormRow>
 
-            <h2>Household items</h2>
-
-            <FormItem
-                type="textarea"
-                id="household"
-                rows={3}
-                value={visitData.household || ''}
-                onChange={handleChange('household')}
-            />
+            <div hidden={!visitData.householdItem}>
+                <h2>Household items</h2>
+                <FormItem
+                    type="textarea"
+                    id="household"
+                    rows={3}
+                    value={visitData.household || ''}
+                    onChange={handleChange('household')}
+                    // hidden={!visitData.householdItem}
+                />
+            </div>
 
             <h2>Notes</h2>
 

--- a/components/Visit/VisitInfoForm.tsx
+++ b/components/Visit/VisitInfoForm.tsx
@@ -57,6 +57,7 @@ export default function VisitInfoForm({
         womensQ: toString(initialVisitData?.womensQ),
         kidsQ: toString(initialVisitData?.kidsQ),
         notes: initialNotes,
+        householdItem: initialVisitData?.household ? true : false,
     });
 
     const handleSubmit = async (e: any) => {
@@ -258,7 +259,6 @@ export default function VisitInfoForm({
                     rows={3}
                     value={visitData.household || ''}
                     onChange={handleChange('household')}
-                    // hidden={!visitData.householdItem}
                 />
             </div>
 

--- a/components/Visit/VisitInfoForm.tsx
+++ b/components/Visit/VisitInfoForm.tsx
@@ -57,7 +57,10 @@ export default function VisitInfoForm({
         womensQ: toString(initialVisitData?.womensQ),
         kidsQ: toString(initialVisitData?.kidsQ),
         notes: initialNotes,
-        householdItem: initialVisitData?.household ? true : false,
+        householdItem:
+            initialVisitData?.householdItem || initialVisitData?.household
+                ? true
+                : false,
     });
 
     const handleSubmit = async (e: any) => {
@@ -83,6 +86,7 @@ export default function VisitInfoForm({
             // transfer boyAge and girlAge to notes with submit
             boyAge: '',
             girlAge: '',
+            household: visitData.householdItem ? visitData.household : '',
         };
     };
 
@@ -91,31 +95,9 @@ export default function VisitInfoForm({
         if (e.target.type === 'checkbox') {
             value = e.target.checked;
         } else value = e.target.value;
-
-        if (key === 'householdItem') {
-            const booleanValue = Boolean(value);
-
-            setVisitData((visitData) => ({
-                ...visitData,
-                // reset household items notes if householdItem is unchecked
-                household: !booleanValue ? '' : visitData.household,
-                householdItem: booleanValue,
-            }));
-        } else {
-            setVisitData((visitData) => ({
-                ...visitData,
-                [key]: value,
-            }));
-        }
-
-        if (onChange) {
-            const updatedData = {
-                ...visitData,
-                [key]: value,
-                ...(key === 'householdItem' && !value && { household: '' }),
-            };
-            onChange(transformData(updatedData));
-        }
+        const data = transformData({ ...visitData, [key]: value });
+        onChange && onChange(data);
+        setVisitData({ ...visitData, [key]: value });
     };
     return (
         <Form onSubmit={handleSubmit}>

--- a/models/index.d.ts
+++ b/models/index.d.ts
@@ -45,6 +45,7 @@ export declare type Visit = {
     readonly clothingBoy?: boolean | null;
     readonly clothingMen?: boolean | null;
     readonly sleepingBag?: boolean | null;
+    readonly food?: boolean | null;
     readonly clothingGirl?: boolean | null;
     readonly clothingWomen?: boolean | null;
     readonly financialAssistance?: number | null;

--- a/models/index.d.ts
+++ b/models/index.d.ts
@@ -50,6 +50,7 @@ export declare type Visit = {
     readonly clothingWomen?: boolean | null;
     readonly financialAssistance?: number | null;
     readonly idv1?: string;
+    readonly householdItem?: boolean | null;
 };
 
 export declare type Settings = {


### PR DESCRIPTION
Added a household item checkbox on the shopping sheet
![image](https://github.com/Kevinjchang98/St-Francis/assets/98987608/3e14b4b1-c538-47db-b69c-3e84b2fd1f07)

Added household item labels on visit form, and visit details
![image](https://github.com/Kevinjchang98/St-Francis/assets/98987608/3f4a5aff-26a8-4f0a-8c36-f7aaf301e359)
![image](https://github.com/Kevinjchang98/St-Francis/assets/98987608/8a8ef00a-b93d-4c28-8acb-f533a6652192)

Added behavior in visit form: uncheck the household item checkbox will reset household item notes. 

issue #115 