### PR TITLE
Feature/116 merge boys and girls clothing checkboxes into one checkbox kids

### DIFF
--- a/__tests__/app/checkin/__snapshots__/Checkin.test.tsx.snap
+++ b/__tests__/app/checkin/__snapshots__/Checkin.test.tsx.snap
@@ -188,30 +188,14 @@ exports[`CheckedIn should match snapshot when clientData fetched 1`] = `
           className="formItem"
         >
           <label
-            htmlFor="clothingBoy"
+            htmlFor="clothingKids"
           >
-            Kids (Boy)
+            Kids
           </label>
           <input
             checked={false}
-            id="clothingBoy"
-            label="Kids (Boy)"
-            onChange={[Function]}
-            type="checkbox"
-          />
-        </div>
-        <div
-          className="formItem"
-        >
-          <label
-            htmlFor="clothingGirl"
-          >
-            Kids (Girl)
-          </label>
-          <input
-            checked={false}
-            id="clothingGirl"
-            label="Kids (Girl)"
+            id="clothingKids"
+            label="Kids"
             onChange={[Function]}
             type="checkbox"
           />

--- a/__tests__/components/Visit/VisitInfoForm.test.tsx
+++ b/__tests__/components/Visit/VisitInfoForm.test.tsx
@@ -46,8 +46,7 @@ describe('Visit Info Form Component', () => {
         render(<VisitInfoForm />);
         expect(screen.queryByText('Men')).toBeInTheDocument();
         expect(screen.queryByText('Women')).toBeInTheDocument();
-        expect(screen.queryByText('Kids (Boy)')).toBeInTheDocument();
-        expect(screen.queryByText('Kids (Girl)')).toBeInTheDocument();
+        expect(screen.queryByText('Kids')).toBeInTheDocument();
         expect(screen.queryByText('Backpack')).toBeInTheDocument();
         expect(screen.queryByText('Sleeping Bag')).toBeInTheDocument();
         expect(screen.queryByText('Bus Ticket')).toBeInTheDocument();
@@ -60,8 +59,7 @@ describe('Visit Info Form Component', () => {
         render(<VisitInfoForm initialVisitData={mockVisitData} />);
         expect(getInputField('Men')).toBe(true);
         expect(getInputField('Women')).toBe(true);
-        expect(getInputField('Kids (Boy)')).toBe(true);
-        expect(getInputField('Kids (Girl)')).toBe(true);
+        expect(getInputField('Kids')).toBe(true);
         expect(getInputField('Backpack')).toBe(true);
         expect(getInputField('Sleeping Bag')).toBe(true);
         expect(getInputField('Bus Ticket')).toBe('1');

--- a/__tests__/components/Visit/__snapshots__/VisitInfoForm.test.tsx.snap
+++ b/__tests__/components/Visit/__snapshots__/VisitInfoForm.test.tsx.snap
@@ -87,30 +87,14 @@ exports[`Visit Info Form Component matches snapshot without any props 1`] = `
         className="formItem"
       >
         <label
-          htmlFor="clothingBoy"
+          htmlFor="clothingKids"
         >
-          Kids (Boy)
+          Kids
         </label>
         <input
           checked={false}
-          id="clothingBoy"
-          label="Kids (Boy)"
-          onChange={[Function]}
-          type="checkbox"
-        />
-      </div>
-      <div
-        className="formItem"
-      >
-        <label
-          htmlFor="clothingGirl"
-        >
-          Kids (Girl)
-        </label>
-        <input
-          checked={false}
-          id="clothingGirl"
-          label="Kids (Girl)"
+          id="clothingKids"
+          label="Kids"
           onChange={[Function]}
           type="checkbox"
         />

--- a/app/profile/[userId]/visit/[visitId]/printout/page.tsx
+++ b/app/profile/[userId]/visit/[visitId]/printout/page.tsx
@@ -47,6 +47,7 @@ export default function Printout({ params }: PrintoutProps) {
                 clothingWomen: 'Womens',
                 clothingBoy: 'Kids (Boy)',
                 clothingGirl: 'Kids (Girl)',
+                clothingKids: 'Kids',
                 backpack: 'Backpack',
                 sleepingBag: 'Sleeping Bag',
                 food: 'Food',

--- a/components/Visit/VisitDetail.tsx
+++ b/components/Visit/VisitDetail.tsx
@@ -14,6 +14,7 @@ function VisitDetail(props: VisitDetailProps) {
         clothingMen,
         clothingWomen,
         clothingGirl,
+        clothingKids,
         mensQ,
         womensQ,
         kidsQ,
@@ -32,13 +33,18 @@ function VisitDetail(props: VisitDetailProps) {
     return (
         <div>
             <h2>Clothing</h2>
-            {clothingMen || clothingWomen || clothingBoy || clothingGirl ? (
+            {clothingMen ||
+            clothingWomen ||
+            clothingBoy ||
+            clothingGirl ||
+            clothingKids ? (
                 <div className={styles.rowContainer}>
                     <div className={styles.row}>
                         <p>{clothingMen && `Men: ${mensQ}`}</p>
                         <p>{clothingWomen && `Women: ${womensQ}`}</p>
                         <p>
-                            {(clothingGirl || clothingBoy) && `Kids: ${kidsQ}`}
+                            {(clothingGirl || clothingBoy || clothingKids) &&
+                                `Kids: ${kidsQ}`}
                         </p>
                     </div>
                 </div>

--- a/components/Visit/VisitInfoForm.tsx
+++ b/components/Visit/VisitInfoForm.tsx
@@ -27,6 +27,7 @@ const defaultVisitData = {
     womensQ: '',
     kidsQ: '',
     householdItem: false,
+    clothingKids: false,
 };
 
 const toInt = (value: string) => parseInt(value) || 0;
@@ -61,6 +62,14 @@ export default function VisitInfoForm({
             initialVisitData?.householdItem || initialVisitData?.household
                 ? true
                 : false,
+
+        // carry existed boy & girl clothing state to clothingKids
+        clothingKids:
+            initialVisitData?.clothingBoy ||
+            initialVisitData?.clothingGirl ||
+            initialVisitData?.clothingKids
+                ? true
+                : false,
     });
 
     const handleSubmit = async (e: any) => {
@@ -80,13 +89,21 @@ export default function VisitInfoForm({
             mensQ: visitData.clothingMen ? toInt(visitData.mensQ) : 0,
             womensQ: visitData.clothingWomen ? toInt(visitData.womensQ) : 0,
             kidsQ:
-                visitData.clothingBoy || visitData.clothingGirl
+                visitData.clothingBoy ||
+                visitData.clothingGirl ||
+                visitData.clothingKids
                     ? toInt(visitData.kidsQ)
                     : 0,
             // transfer boyAge and girlAge to notes with submit
             boyAge: '',
             girlAge: '',
+
+            // clear out household if householdItem is unchecked
             household: visitData.householdItem ? visitData.household : '',
+
+            // turn off boy & girl clothing since they've been merged to clothingKids
+            clothingBoy: false,
+            clothingGirl: false,
         };
     };
 
@@ -139,17 +156,10 @@ export default function VisitInfoForm({
                 <FormRow className={styles.rowItems}>
                     <FormItem
                         type="checkbox"
-                        id="clothingBoy"
-                        label="Kids (Boy)"
-                        checked={!!visitData.clothingBoy}
-                        onChange={handleChange('clothingBoy')}
-                    />
-                    <FormItem
-                        type="checkbox"
-                        id="clothingGirl"
-                        label="Kids (Girl)"
-                        checked={!!visitData.clothingGirl}
-                        onChange={handleChange('clothingGirl')}
+                        id="clothingKids"
+                        label="Kids"
+                        checked={!!visitData.clothingKids}
+                        onChange={handleChange('clothingKids')}
                     />
                     <FormItem
                         type="number"
@@ -157,7 +167,9 @@ export default function VisitInfoForm({
                         value={visitData.kidsQ}
                         onChange={handleChange('kidsQ')}
                         hidden={
-                            !visitData.clothingBoy && !visitData.clothingGirl
+                            !visitData.clothingBoy &&
+                            !visitData.clothingGirl &&
+                            !visitData.clothingKids
                         }
                     />
                 </FormRow>

--- a/models/index.d.ts
+++ b/models/index.d.ts
@@ -51,6 +51,7 @@ export declare type Visit = {
     readonly financialAssistance?: number | null;
     readonly idv1?: string;
     readonly householdItem?: boolean | null;
+    readonly clothingKids?: boolean | null;
 };
 
 export declare type Settings = {


### PR DESCRIPTION
Merge clothingBoy and clothingGirl to clothingKids. 

For new visits, only the new clothingKids checkbox is available on visitInfoForm. 
For existing visit data, carry boy & girl clothing state to clothingKids, then turn off boy & girl clothing upon saving to avoid duplicate checkboxes printing out. 

![image](https://github.com/Kevinjchang98/St-Francis/assets/98987608/b86d206e-dbb8-4f14-b0d7-e04a4643dc42)

#116 